### PR TITLE
Change baseurl in config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Ce guide s’adresse aux entreprises qui souhaitent financer leur
   développement, garantir leurs crédits, et mesurer leurs progrès à l’aide
   d’indicateurs financiers.
-baseurl: "/growth-guide" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://guide.memo.bank" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: memobank
 github_username: memobank


### PR DESCRIPTION
This pull request changes the value of the `baseurl` field in Jekyll's config file to prevent errors. Now that our website is no longer a subfolder of a domain linked to GitHub, I guess that the baseurl field is no longer necessary.

Hint:

- https://guide.memo.bank/growth-guide/assets/css/just-the-docs-default.css is now broken
- https://guide.memo.bank/assets/css/just-the-docs-default.css works well (note the absence of `/growth-guide/`)