### PR TITLE
Add proper footer and article description property

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,6 @@ gem "github-pages", group: :jekyll_plugins
 group :jekyll_plugins do
   gem "jekyll-github-metadata"
   gem "jekyll-seo-tag"
-  gem "kramdown"
-  gem "rouge"
   gem "jekyll-sitemap"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.5.1)
+    activesupport (6.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -267,8 +267,6 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   just-the-docs (= 0.4.0.rc2)
-  kramdown
-  rouge
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/_config.yml
+++ b/_config.yml
@@ -19,9 +19,9 @@
 # in the templates via {{ site.myvariable }}.
 
 lang: fr
-title: Le guide Memo Bank des entreprises en croissance
+title: Guide Memo Bank
 tagline: >- # the tagline is a short description
-  Un guide pratique destiné aux entreprises qui grandissent vite.
+  Le guide Memo Bank des entreprises en croissance
 description: >- # this means to ignore newlines until "baseurl:"
   Ce guide s’adresse aux entreprises qui souhaitent financer leur
   développement, garantir leurs crédits, et mesurer leurs progrès à l’aide

--- a/_config.yml
+++ b/_config.yml
@@ -56,16 +56,6 @@ defaults:
     values:
       image: /assets/images/cards/card-default.png
 
-# Conversion
-markdown: kramdown
-highlighter: rouge
-
-# Markdown Processors
-kramdown:
-  input: GFM
-  auto_ids: true
-  syntax_highlighter: rouge
-
 # Permalink
 permalink: /:path
 
@@ -82,9 +72,8 @@ remote_theme: just-the-docs/just-the-docs@v0.4.0.rc2
 plugins:
   - jekyll-github-metadata
   - jekyll-seo-tag
-  - rouge
-  - kramdown
   - jekyll-sitemap
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
+# Jekyll configuration
 lang: fr
 title: Guide Memo Bank
 tagline: >- # the tagline is a short description
@@ -30,6 +31,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://guide.memo.bank" # the base hostname & protocol for your site, e.g. http://example.com
 github_username: memobank
 email: contact@memo.bank
+markdown: GFM
+highlighter: rouge
 
 # SEO
 ## Twitter metadata

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,6 +1,15 @@
+<p>
+  <a href="https://memo.bank">Memo&nbsp;Bank</a> est une banque indépendante
+  pour les PME. Nous aidons les entreprises à grandir en leur proposant des
+  <a href="https://memo.bank/fonctionnalites">services bancaires performants</a>
+  et l’accompagnement de
+  <a href="https://memo.bank/banquiers">banquiers expérimentés</a>. Avec
+  Memo&nbsp;Bank, les dirigeants et leurs équipes passent moins de temps sur le
+  site de leur banque et plus de temps face à leurs clients.
+</p>
 <p class="text-small text-grey-dk-100 mb-0">
-  &copy; 2022 Memo Bank. Publié sous license
+  &copy; 2022 Memo&nbsp;Bank. Publié sous license
   <a href="https://github.com/memobank/growth-guide/blob/main/LICENSE.txt"
     >Creative Commons Attribution 4.0 International</a
-  >. Hébergé sur <a href="https://pages.github.com">GitHub Pages</a>.
+  >. Hébergé sur <a href="https://pages.github.com">GitHub&nbsp;Pages</a>.
 </p>

--- a/_sass/color_schemes/memo.scss
+++ b/_sass/color_schemes/memo.scss
@@ -17,28 +17,25 @@ $font-size-9: 40px;
 $font-size-10: 45px;
 $font-size-10-sm: 50px;
 // Colors
-$grayscale-primary: #18191b;
-$grayscale-secondary: #303236;
-$grayscale-tertiary: #797e86;
-$blue-memo: #0b5dd0;
-$blue-dark: #0d4189;
-$blue-light: #f0f6fe;
-$grey: #e1e1e6;
-$grey-light: #f9f9fa;
-$sidebar-color: $blue-light;
-$body-heading-color: $grayscale-primary;
-$body-text-color: $grayscale-secondary;
-$link-color: $blue-memo;
-$btn-primary-color: $blue-memo;
+$grey-dk-300: #18191b; // grayscale primary
+$grey-dk-250: #303236; // grayscale secondary
+$grey-dk-200: #797e86; // grayscale tertiary
+$blue-300: #0d4189; // blue dark
+$blue-200: #0b5dd0; // blue memo
+$blue-000: #f0f6fe; // blue light
+$sidebar-color: $blue-000;
+$body-heading-color: $grey-dk-300;
+$body-text-color: $grey-dk-250;
+$link-color: $blue-200;
+$btn-primary-color: $blue-200;
 $feedback-color: darken($sidebar-color, 3%);
-$search-result-preview-color: $blue-memo;
-$nav-child-link-color: $grayscale-tertiary;
+$search-result-preview-color: $blue-200;
+$nav-child-link-color: $grey-dk-250;
+// Borders
+$border: 0.5px solid;
 // Grid system
-$header-height: 80px;
-$content-width: 720px;
 $nav-width: 248px;
 $nav-width-md: 232px;
 $nav-list-item-height: $sp-7;
-// Borders
-$border: 0.5px solid;
-$border-color: $grey;
+$content-width: 720px;
+$header-height: 80px;

--- a/financements/aides-publiques.md
+++ b/financements/aides-publiques.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Aides publiques
+description: Les aides publiques sont un type de financement non-dilutif.
 image: /assets/images/cards/card-financements-aides-publiques.png
 parent: Financements
 ---

--- a/financements/business-angels.md
+++ b/financements/business-angels.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Business Angels
+decription: Les business angels proposent des financements dilutifs.
 image: /assets/images/cards/card-financements-business-angels.png
 parent: Financements
 ---

--- a/financements/concours.md
+++ b/financements/concours.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Concours
+decription: Les concours d’entrepreneuriat peuvent vous aider à vous financer.
 image: /assets/images/cards/card-financements-concours.png
 parent: Financements
 ---

--- a/financements/credits-bancaires.md
+++ b/financements/credits-bancaires.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Crédits bancaires
+description: Les crédits bancaires sont un type de financement non-dilutif.
 image: /assets/images/cards/card-financements-credits-bancaires.png
 parent: Financements
 ---

--- a/financements/crowdlending.md
+++ b/financements/crowdlending.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Crowdlending
+description: Le crowdlending est un type de financement participatif.
 image: /assets/images/cards/card-financements-crowdlending.png
 parent: Financements
 ---

--- a/financements/famille-amis.md
+++ b/financements/famille-amis.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Famille et amis
+decription: La famille et les amis peuvent être une source de financement.
 image: /assets/images/cards/card-financements-famille-amis.png
 parent: Financements
 ---

--- a/financements/fonds-capital-risque.md
+++ b/financements/fonds-capital-risque.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Fonds de capital-risque
+decription: Les fonds de capital-risque (VC) proposent des financements dilutifs.
 image: /assets/images/cards/card-financements-fonds-capital-risque.png
 parent: Financements
 ---

--- a/financements/index.md
+++ b/financements/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Financements
+description: Découvrez les financements les plus courants pour les PME.
 image: /assets/images/cards/card-financements-index.png
 nav_order: 2
 has_children: true

--- a/garanties/caution-personnelle.md
+++ b/garanties/caution-personnelle.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Caution personnelle
+description: Définition de la caution personnelle simple ou solidaire.
 image: /assets/images/cards/card-garanties-caution-personnelle.png
 parent: Garanties
 ---

--- a/garanties/gage-especes.md
+++ b/garanties/gage-especes.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Gage-espèces
+description: Définition du gage-espèces, un type de garantie bancaire.
 image: /assets/images/cards/card-garanties-gage-especes.png
 parent: Garanties
 ---

--- a/garanties/garantie-fei.md
+++ b/garanties/garantie-fei.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Garantie FEI
+description: Définition de la garantie FEI, une garantie bancaire euroépenne.
 image: /assets/images/cards/card-garanties-garantie-fei.png
 parent: Garanties
 ---

--- a/garanties/garanties-bpifrance.md
+++ b/garanties/garanties-bpifrance.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Garanties Bpifrance
+description: Définition des garanties Bpifrance, les contre-garanties de la BPI.
 image: /assets/images/cards/card-garanties-garanties-bpifrance.png
 parent: Garanties
 ---

--- a/garanties/index.md
+++ b/garanties/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Garanties
+description: Découvrez les garanties bancaires les plus courantes.
 image: /assets/images/cards/card-garanties-index.png
 nav_order: 3
 has_children: true

--- a/garanties/nantissement-fonds-commerce.md
+++ b/garanties/nantissement-fonds-commerce.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Nantissement
+description: Définition du nantissement de fonds de commerce.
 image: /assets/images/cards/card-garanties-nantissement-fonds-commerce.png
 parent: Garanties
 ---

--- a/indicateurs/annual-recurring-revenue.md
+++ b/indicateurs/annual-recurring-revenue.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: ARR
+description: Découvrez comment calculer votre revenu annuel récurrent.
 image: /assets/images/cards/card-indicateurs-annual-recurring-revenue.png
 parent: Indicateurs
 ---

--- a/indicateurs/churn.md
+++ b/indicateurs/churn.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Churn
+description: Découvrez comment calculer votre taux d’attrition (churn).
 image: /assets/images/cards/card-indicateurs-churn.png
 parent: Indicateurs
 ---

--- a/indicateurs/cout-acquisition-client.md
+++ b/indicateurs/cout-acquisition-client.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: CAC
+description: Découvrez comment calculer votre coût d’acquisition client (CAC).
 image: /assets/images/cards/card-indicateurs-cout-acquisition-client.png
 parent: Indicateurs
 ---

--- a/indicateurs/customer-lifetime-value.md
+++ b/indicateurs/customer-lifetime-value.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: LTV
+description: Découvrez comment calculer votre customer lifetime value (LTV).
 image: /assets/images/cards/card-indicateurs-customer-lifetime-value.png
 parent: Indicateurs
 ---

--- a/indicateurs/index.md
+++ b/indicateurs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Indicateurs
+description: Découvrez comment calculter votre ARR, MRR, CAC, churn et LTV…
 image: /assets/images/cards/card-indicateurs-index.png
 nav_order: 4
 has_children: true

--- a/indicateurs/monthly-recurring-revenue.md
+++ b/indicateurs/monthly-recurring-revenue.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: MRR
+description: Découvrez comment calculer votre revenu mensuel récurrent.
 image: /assets/images/cards/card-indicateurs-monthly-recurring-revenue.png
 parent: Indicateurs
 ---

--- a/indicateurs/ratio-ltv-cac.md
+++ b/indicateurs/ratio-ltv-cac.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Ratio LTV/CAC
+description: Découvrez comment calculer votre ratio LTV/CAC.
 image: /assets/images/cards/card-indicateurs-ratio-ltv-cac.png
 parent: Indicateurs
 ---


### PR DESCRIPTION
This pull request:

- Adds a proper “About Memo Bank“ paragraphe to the footer of our site, that is to say on every page.
- Removes useless plugin (Rouge and Kramdown). Turns out we don't need syntax highlighting.
- Adds a description property to our article in order to improve the metadata that populates our link preview.