### PR TITLE
Install Google Tag Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+	bundle install
+
+run:
+	bundle exec jekyll serve

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,16 @@
+{% if jekyll.environment == "production" %}
+<!-- Google Tag Manager -->
+<script>
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != "dataLayer" ? "&l=" + l : "";
+    j.async = true;
+    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, "script", "dataLayer", "GTM-WWWC75H");
+</script>
+<!-- End Google Tag Manager -->
+{% endif %}

--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -1,0 +1,12 @@
+{% if jekyll.environment == "production" %}
+<!-- Google Tag Manager (noscript) -->
+<noscript
+  ><iframe
+    src="https://www.googletagmanager.com/ns.html?id=GTM-WWWC75H"
+    height="0"
+    width="0"
+    style="display: none; visibility: hidden"
+  ></iframe
+></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{% endif %}


### PR DESCRIPTION
This PR installs Google Tag Manager by inserting scripts recommended by Google to the matching customization hooks offered by `just-the-docs`.

The scripts are only run when Jekyll is run in the `production` environment. To test locally, run `JEKYLL_ENV=production make run`.

As a side effect, this MR adds a `Makefile` so that the following actions can be run more easily:

* `make install` will install Ruby dependencies via `bundler`;
* `make run` will run Jekyll locally.