### PR TITLE
Add theme color value to name attribute

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -14,3 +14,7 @@
 </script>
 <!-- End Google Tag Manager -->
 {% endif %}
+
+<!-- Suggested color that user agents should use to customize 
+the display of the page or of the surrounding user interface -->
+<meta name="theme-color" content="#0A1941" />


### PR DESCRIPTION
This pull request closes #17. 

See MDN for more: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color