### PR TITLE
Hide anchor link on h1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ read_more: Lire notre article
 
 # Build settings
 # Jekyll feature allowing to build sites with GitHub-hosted themes.
-remote_theme: just-the-docs/just-the-docs@v0.4.0.rc2
+remote_theme: just-the-docs/just-the-docs@v0.4.0.rc3
 # The list of Jekyll plugins we rely on.
 plugins:
   - jekyll-github-metadata

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -133,11 +133,6 @@ h4,
   line-height: 1rem;
 }
 // Disable anchor links on h1 titles
-h1:hover > .anchor-heading {
-  pointer-events: none;
-  cursor: default;
+h1 > .anchor-heading {
   display: none;
-  svg {
-    visibility: hidden;
-  }
 }

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -132,3 +132,12 @@ h4,
   font-size: $font-size-3 !important;
   line-height: 1rem;
 }
+// Disable anchor links on h1 titles
+h1:hover > .anchor-heading {
+  pointer-events: none;
+  cursor: default;
+  display: none;
+  svg {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
This pull request updates our theme in order to close #22. It also hides the anchor link icon on h1 titles, because there's no difference between the link to a page and the link to the h1 of that said page—because we're only using one h1 per page.

## Preview

Note how the anchor icon is now disabled on hover. Sure, it's not perfect, since it's done using CSS, meaning that users can still get a h1 anchor link if they click on the exact location of the (hidden) anchor icon, but that's a decent start in my view.

| Before | After |
|---|---|
|![2022-10-14-Safari Technology Preview](https://user-images.githubusercontent.com/3286488/195810161-a822dafa-0a8b-46a2-8c1e-7a74c32549ce.png)|![2022-10-14-Safari Technology Preview 3](https://user-images.githubusercontent.com/3286488/195810201-a98330d5-e7c1-483f-9c2e-426925f84789.png)|