### PR TITLE
Fix broken internal links

### DIFF
--- a/ratios/index.md
+++ b/ratios/index.md
@@ -14,22 +14,22 @@ has_toc: false
 
 Ce ratio compare les différentes ressources qu’utilise votre entreprise pour se financer.
 
-[{{ site.read_more }}]({% link ratios/ratio-autonomie-financiere.md %})
+[{{ site.read_more }}]({% link ratios/ratio-autonomie-financiere.md %})
 
 ## Ratio du coût de la dette bancaire
 
 Le ratio du coût de la dette bancaire compare les intérêts que paie votre entreprise sur une année, avec sa capacité à dégager des excédents de trésorerie grâce à son seul cycle d’exploitation (toujours sur une année).
 
-[{{ site.read_more }}]({% link ratios/ratio-cout-dette-bancaire.md %})
+[{{ site.read_more }}]({% link ratios/ratio-cout-dette-bancaire.md %})
 
 ## Ratio de capacité de remboursement
 
 Le ratio de capacité de remboursement est égal au rapport entre la somme de vos dettes, et votre capacité d’autofinancement (CAF).
 
-[{{ site.read_more }}]({% link ratios/ratio-capacite-remboursement.md %})
+[{{ site.read_more }}]({% link ratios/ratio-capacite-remboursement.md %})
 
 ## Ratio de partage des risques
 
 Le ratio de partage des risques est égal au rapport entre la somme de vos dettes bancaires, et la sommes de vos fonds propres. Il permet à votre banquier d’évaluer la dépendance de votre entreprise aux financements externes.
 
-[{{ site.read_more }}]({% link ratios/ratio-partage-risques.md %})
+[{{ site.read_more }}]({% link ratios/ratio-partage-risques.md %})


### PR DESCRIPTION
This pull request removes the non-breaking spaces that were causing our site to break on build. Jekyll can't seem to be able to build our site if some Liquid tags contain non-breaking spaces. That makes sense. I guess I'll have to update the REGEX I'm using to spot missing non-breaking spaces. 😅

Note: do not put non-breaking spaces inside Liquid tags—before the closing `%}` in the following link for example:

```
[{{ site.read_more }}]({% link ratios/ratio-capacite-remboursement.md %})
```