### PR TITLE
Edit GitHub workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -4,7 +4,7 @@ name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/index.md
+++ b/index.md
@@ -25,4 +25,4 @@ Bonne lecture.
 - [Voir nos articles sur les offres de financement]({% link financements/index.md %})
 - [Voir nos articles sur les garanties financières]({% link garanties/index.md %})
 - [Voir nos articles sur les indicateurs à suivre de votre côté]({% link indicateurs/index.md %})
-- [Voir nos articles sur les ratios utilisés par les banquiers]({% link indicateurs/index.md %})
+- [Voir nos articles sur les ratios utilisés par les banquiers]({% link ratios/index.md %})


### PR DESCRIPTION
This pull request replaces a variable (`[$default-branch]`) with an actual branch name (`main`) in the GitHub workflow we're using to deploy ou Jekyll site. This should ensure our workflow automatically runs after a PR has been merged into `main`.

Although the workflow we're using [was created by GitHub itself](https://github.com/actions/starter-workflows/blob/main/pages/jekyll-gh-pages.yml), the use of the `$default-branch` variable doesn't seem legit—it's nowhere to be found in [GitHub's documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters) for example. I guess I missed something along the way here. 🤔 Anyway, here's a fix. 💁‍♂️